### PR TITLE
Add line separator at output start

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -141,7 +141,7 @@ export default class SizePlugin {
 			output += msg + sizeText + '\n';
 		}
 		if (output) {
-			console.log(output);
+			console.log('\n' + output);
 		}
 	}
 


### PR DESCRIPTION
Without leading line seperator output looks like this for me using vue-cli:
![image](https://user-images.githubusercontent.com/7964583/49868135-8f827b80-fe1d-11e8-94a8-ee2ebb946fa3.png)
